### PR TITLE
確認用ウィンドウの大きさ自動調整　タイマの終了処理正規化

### DIFF
--- a/manuallockscreen.cpp
+++ b/manuallockscreen.cpp
@@ -25,6 +25,7 @@ ManualLockScreen::~ManualLockScreen()
 {
     if(_timer != nullptr)
     {
+        _timer->stop();
         delete _timer;
     }
     delete ui;
@@ -42,6 +43,7 @@ void ManualLockScreen::on_timer_timeout()
                                           _gameWindowRect.width(),
                                           _gameWindowRect.height());
     }
+    _gameWindowImage.resize(screenPixmap.rect().width(), screenPixmap.rect().height());
     _gameWindowImage.setPixmap(screenPixmap);
     _gameWindowImage.show();
 }


### PR DESCRIPTION
#1 
ゲームウィンドウの手動調整時の確認ウィンドウに、画像の大きさに合わせて自動調整する処理を追加
ゲームウィンドウの手動調整ダイアログの、タイマの終了処理を正規化